### PR TITLE
Enable toggling ssl verification

### DIFF
--- a/aioarango/client.py
+++ b/aioarango/client.py
@@ -49,6 +49,7 @@ class ArangoClient:
         http_client: Optional[HTTPClient] = None,
         serializer: Callable[..., str] = lambda x: dumps(x),
         deserializer: Callable[[str], Any] = lambda x: loads(x),
+        verify_ssl: bool = True,
     ) -> None:
         if isinstance(hosts, str):
             self._hosts = [host.strip("/") for host in hosts.split(",")]
@@ -68,7 +69,7 @@ class ArangoClient:
         self._http = http_client or DefaultHTTPClient()
         self._serializer = serializer
         self._deserializer = deserializer
-        self._sessions = [self._http.create_session(h) for h in self._hosts]
+        self._sessions = [self._http.create_session(h, verify_ssl) for h in self._hosts]
 
     def __repr__(self) -> str:
         return f"<ArangoClient {','.join(self._hosts)}>"

--- a/aioarango/http.py
+++ b/aioarango/http.py
@@ -64,7 +64,7 @@ class DefaultHTTPClient(HTTPClient):
     REQUEST_TIMEOUT = 60
     RETRY_ATTEMPTS = 3
 
-    def create_session(self, host: str) -> httpx.AsyncClient:
+    def create_session(self, host: str, verify: bool = True) -> httpx.AsyncClient:
         """Create and return a new session/connection.
 
         :param host: ArangoDB host URL.
@@ -72,7 +72,7 @@ class DefaultHTTPClient(HTTPClient):
         :returns: httpx client object
         :rtype: httpx.AsyncClient
         """
-        transport = httpx.AsyncHTTPTransport(retries=self.RETRY_ATTEMPTS)
+        transport = httpx.AsyncHTTPTransport(retries=self.RETRY_ATTEMPTS, verify=verify)
         return httpx.AsyncClient(transport=transport)
 
     async def send_request(


### PR DESCRIPTION
Uses different HTTPClient then original python-arango. Allows to bypass ssl verification in httpx with this PR.